### PR TITLE
Adapt to perl-5.20.0, where an integer can get encoded as an NV without ...

### DIFF
--- a/package/yast2-perl-bindings.changes
+++ b/package/yast2-perl-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  4 16:49:55 CEST 2014 - mls@suse.de
+
+- Adapt to perl-5.20.0, where an integer can get encoded as an
+  NV without the PV flag being set
+- 3.1.2
+
+-------------------------------------------------------------------
 Thu Oct 17 14:13:21 UTC 2013 - mvidner@suse.com
 
 - Fix untranslated texts in yast2-users: call bindtextdomain

--- a/package/yast2-perl-bindings.spec
+++ b/package/yast2-perl-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-perl-bindings
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YPerl.cc
+++ b/src/YPerl.cc
@@ -714,7 +714,7 @@ getInteger (SV *sv, YCPValue &out)
     else
     {
 	const char *pv = SvPV_nolen (sv);
-	if (SvPOK (sv))
+	if (SvPOK (sv) || SvNOK (sv))
 	{
 	    char *errptr;
 	    long long int lli = strtoll (pv, &errptr, 10);


### PR DESCRIPTION
...the PV flag being set
