### PR TITLE
Use the new Docker image at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_install:
 script:
   # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
   # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
-  - docker run -it -e TRAVIS=1 yast-perl-bindings-image yast-travis-cpp
+  # $TRAVIS_JOB_ID is not strictly required but be consistent with the other packages...
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-perl-bindings-image yast-travis-cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
-language: ruby
+language: bash
 services:
   - docker
 
 before_install:
-  - docker build -t yast-pkg-bindings-image .
+  - docker build -t yast-perl-bindings-image .
 script:
-  # the "yast-travis-cpp" script is included in the base yastdevel/cpp-tw image
-  # see https://github.com/yast/docker-yast-cpp-tw/blob/master/yast-travis-cpp
-  - docker run -it yast-pkg-bindings-image yast-travis-cpp
+  # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
+  # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
+  - docker run -it -e TRAVIS=1 yast-perl-bindings-image yast-travis-cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM yastdevel/cpp-tw
+FROM yastdevel/cpp
 # Some tests are written in Ruby so the yast2-ruby-bindings package is needed...
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends yast2-ruby-bindings
-COPY . /tmp/sources
+COPY . /usr/src/app
 


### PR DESCRIPTION
- I found out that Travis supports `generic` language, with `bash`, `sh` and `shell` aliases, which should be less error prone - possibly less issues on the Travis side with a smaller/simpler base image. We do not run any Ruby code out of Docker anyway.
- Use the renamed Docker image - originally I wanted to have a separate image for Head (based on Tumbleweed) and separate images for each maintenance branches, but the common upstream Docker way is to have a single Docker repository based on a single GitHub repo and have separate Docker tags based on the Git branches.
So instead of `cpp-tw` and `cpp-sle12-sp2` (or similar) Docker images and their GitHub repositories we will have `cpp` (which is the same as `cpp:latest`) and `cpp:sle12-sp2` images at Docker and a single GitHub repo.
- Use the `/usr/src/app` directory for storing the sources in the Docker container. The same place is used in the other official Docker images e.g. [Ruby](https://hub.docker.com/_/ruby/), [JRuby](https://hub.docker.com/_/jruby/), [Node,js](https://hub.docker.com/_/node/),... Just be more compatible with the Docker upstream. The new Docker YaST images expects the sources at this place.
- Set `TRAVIS=1` environment to be compatible with normal non-Docker Travis environment. (Not used here yet but to avoid possible confusion in the future.)