### PR TITLE
Disable the Perl syntax check at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ script:
   # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
   # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
   # $TRAVIS_JOB_ID is not strictly required but be consistent with the other packages...
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-perl-bindings-image yast-travis-cpp
+  # skip the Perl syntax check, it fails in the pluglib-bindings testsuite
+  # FIXME: enable it after removing pluglib-bindings
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-perl-bindings-image yast-travis-cpp -x perl_syntax

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Travis:  [![Build Status](https://travis-ci.org/yast/yast-perl-bindings.svg?bran
 Jenkins: [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-perl-bindings-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-perl-bindings-master/)
 
 
+### TODO
+
+- [ ] Remove the obsolete `pluglib-bindings` subdirectory
+- [ ] Enable the Perl syntax check at Travis

--- a/pluglib-bindings/README
+++ b/pluglib-bindings/README
@@ -1,3 +1,9 @@
+NOTE: the pluglib-bindings library is obsolete and it will be dropped!
+
+DO NOT USE IT!!
+
+--
+
 Supported data types:
 ---------------------
 


### PR DESCRIPTION
- It fails in the pluglib-bindings testsuite
- The `pluglib-bindings` support is obsolete and should be dropped later
- Travis still fails as it requires a new image with updated `yast-travis-cpp` script


## TODO

- [x] Wait for the updated Docker image and restart Travis later