### PR TITLE
Fix the Locale after Initializing Embedded Perl Interpreter

### DIFF
--- a/package/yast2-perl-bindings.changes
+++ b/package/yast2-perl-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 21 14:22:32 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fix the locale after initializing embedded Perl interpreter
+  (bsc#1216689) 
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-perl-bindings.spec
+++ b/package/yast2-perl-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-perl-bindings
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YPerl.cc
+++ b/src/YPerl.cc
@@ -155,7 +155,7 @@ void YPerl::fixupLocale()
     // Those functions only query the current values,
     // they don't change anything.
 
-    char * locale  = setlocale( LC_ALL, "" );
+    char * locale  = setlocale( LC_ALL, 0 );
     char * codeset = nl_langinfo( CODESET );
 
     y2milestone( "locale:  %s", locale  ? locale  : "<NULL>" );

--- a/src/YPerl.cc
+++ b/src/YPerl.cc
@@ -13,7 +13,7 @@
   File:	      YPerl.cc
 
   Maintainer: Martin Vidner <mvidner@suse.cz>
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is the common part, defining data type conversions.
 
@@ -26,6 +26,8 @@
 #include <sstream>
 #include <iomanip>
 #include <limits>
+#include <locale.h>
+#include <langinfo.h>
 
 // Perl stuff
 #define PERL_NO_GET_CONTEXT     /* we want efficiency, man perlguts */
@@ -114,6 +116,7 @@ YPerl::YPerl()
 		0 );	// env
 
     PrependModulePath (internalPerlInterpreter ());
+    fixupLocale();
 }
 
 YPerl::YPerl(pTHX)
@@ -141,6 +144,24 @@ YPerl::yPerl()
 
     return _yPerl;
 }
+
+
+void YPerl::fixupLocale()
+{
+    y2milestone( "Switching to the global locale" );
+
+    uselocale( LC_GLOBAL_LOCALE ); // bsc#1216689
+
+    // Those functions only query the current values,
+    // they don't change anything.
+
+    char * locale  = setlocale( LC_ALL, "" );
+    char * codeset = nl_langinfo( CODESET );
+
+    y2milestone( "locale:  %s", locale  ? locale  : "<NULL>" );
+    y2milestone( "codeset: %s", codeset ? codeset : "<NULL>" );
+}
+
 
 void
 YPerl::acceptInterpreter (pTHX)

--- a/src/YPerl.h
+++ b/src/YPerl.h
@@ -12,7 +12,7 @@
 
   File:	      YPerl.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
   	      Martin Vidner <mvidner@suse.cz>
 /-*/
 
@@ -72,7 +72,7 @@ public:
      **/
     static YCPValue destroy();
 
-    
+
 protected:
 
     /**
@@ -93,6 +93,20 @@ protected:
     ~YPerl();
 
     /**
+     * Fix up the locale and encoding which may have been changed by internal
+     * functions in the embedded Perl interpreter in newer Perl versions
+     * (Perl 5.36 from mid-2023). See bsc#1216689.
+     *
+     * Basically, Perl switched back from UTF-8 to ANSI_X3.4-1968 (7-bit
+     * ASCII), so special characters like Japanese, German umlauts (ÄÖÜäöüß) or
+     * Czech accented characters were broken (replaced by '?').
+     *
+     * This affected translated messages read via gettext() as well as file
+     * output.
+     **/
+    void fixupLocale();
+
+    /**
      * Returns the internal embedded Perl interpreter.
      **/
     PerlInterpreter * internalPerlInterpreter() const
@@ -104,7 +118,7 @@ public:
      **/
     YCPValue callInner (string module, string function, bool method,
 			YCPList argList, constFunctionTypePtr function_type);
-    
+
     /**
      * Create a new Perl scalar value from a YCP value.
      * @param composite If an undef should go to an array/hash, it must be represented specially.
@@ -211,7 +225,7 @@ protected:
      * Convert a Perl array to a YCPList.
      **/
     YCPList fromPerlArray (AV * array, constTypePtr wanted_type);
-    
+
     /**
      * Convert a Perl hash to a YCPMap.
      **/


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1216689


## Problem

On Tumbleweed, Japanese characters and special characters in German (ÄÖÜäöüß) and Czech and probably many more languages were broken (replaced by '?') for messages from libstorage-ng and from Perl code.

![tumbleweed-ja](https://github.com/yast/yast-perl-bindings/assets/11538225/3fd296e5-0751-40f3-a007-baf271d37854)

![TW-net-storage-proposal-cs-broken](https://github.com/yast/yast-perl-bindings/assets/11538225/9aa18c9e-095f-44e7-bccc-7cf3065c37ed)



## Cause

After long investigations, we found out that the embedded Perl interpreter now changes locale settings, and we would always just get `ANSI_X3.4-1968` (7 bit ASCII) for the codeset from functions like `nl_langinfo( CODESET )`, not `UTF-8` as expected.


## Fix / Workaround

After initializing the embedded Perl interpreter, we now explicitly switch back to the _global_ locale with `uselocale( LC_GLOBAL_LOCALE )`.

This is strictly a workaround to get YaST going. Probably this needs to be fixed on the Perl level; they are now messing up everybody else's locale for any process using an embedded Perl interpreter.

But fixing it on the Perl level may not be so easy, and it may take a while for such a true fix to arrive.


## Test

Arvin already successfully tested the one-liner fix which is the core of this in the inst-sys against the problematic cases.


## Identifying a Fixed Version

Check `/var/log/YaST2/y2log` for those messages:

```
... [Y2Perl] YPerl.cc(fixupLocale):151 Switching to the global locale
... [Y2Perl] YPerl.cc(fixupLocale):161 locale:  de_DE.utf8
... [Y2Perl] YPerl.cc(fixupLocale):162 codeset: UTF-8
```
