### PR TITLE
Revert Last Locale Fix/Workaround to avoid Perl Crashing

### DIFF
--- a/package/yast2-perl-bindings.changes
+++ b/package/yast2-perl-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  6 14:03:01 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Revert the last locale fix to avoid Perl crashing (bsc#1220375)
+- 5.0.2
+
+-------------------------------------------------------------------
 Wed Feb 21 14:22:32 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fix the locale after initializing embedded Perl interpreter

--- a/package/yast2-perl-bindings.spec
+++ b/package/yast2-perl-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-perl-bindings
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YPerl.cc
+++ b/src/YPerl.cc
@@ -148,9 +148,20 @@ YPerl::yPerl()
 
 void YPerl::fixupLocale()
 {
+#if 0
     y2milestone( "Switching to the global locale" );
 
     uselocale( LC_GLOBAL_LOCALE ); // bsc#1216689
+    // Unfortunately, while this fixed bsc#1216689 (broken special characters),
+    // it seems to have caused bsc#1220375 (yast2-users crashing with a
+    // Zypp-Main process in a busy loop), so we needed to revert this again.
+#else
+    // Some log output to be able to identify versions with and without the
+    // above fix/workaround.
+    //
+    // TO DO: Remove this whole #if 0 .. #endif block after a real fix.
+    y2milestone( "NOT switching to the global locale - leaving whatever Perl did" );
+#endif
 
     // Those functions only query the current values,
     // they don't change anything.


### PR DESCRIPTION
## Bugzilla

- https://bugzilla.suse.com/show_bug.cgi?id=1220375
  (yast2-users crash with a Zypp-Main process busy looping)

- https://bugzilla.suse.com/show_bug.cgi?id=1216689
  (Japanese / German /Czech special characters broken in libstorage and Perl messages)

- https://bugzilla.suse.com/show_bug.cgi?id=1220195
  (Embedded Perl Interpreter Messes up Locale Environment of Calling Process)


## Problem

The last PR #31 that created a workaround for bsc#1220195 to fix bsc#1216689 appears to have caused bsc#1220375:

That workaround/fix caused `yast2 users` to crash with a `Zypp-main` process in a busy loop, and with parse errors (in `/var/lib/YaST/nohup.txt`):

```
Compilation failed in require at
	/usr/lib/perl5/5.38.2/x86_64-linux-thread-multi/Data/Dumper.pm line 20 (#2)
    (F) Perl could not compile a file specified in a require statement.
    Perl uses this generic message when none of the errors that it
    encountered were severe enough to halt compilation immediately.
```

Complete messages: 
<Details>

```
Attempt to reload constant.pm aborted (#1)
    (F) You tried to load a file with use or require that failed to
    compile once already.  Perl will not try to compile this file again
    unless you delete its entry from %INC.  See "require" in perlfunc and
    "%INC" in perlvar.
    
Compilation failed in require at
	/usr/lib/perl5/5.38.2/x86_64-linux-thread-multi/Data/Dumper.pm line 20 (#2)
    (F) Perl could not compile a file specified in a require statement.
    Perl uses this generic message when none of the errors that it
    encountered were severe enough to halt compilation immediately.
    
BEGIN failed--compilation aborted at
	/usr/lib/perl5/5.38.2/x86_64-linux-thread-multi/Data/Dumper.pm line 20 (#3)
    (F) An untrapped exception was raised while executing a BEGIN
    subroutine.  Compilation stops immediately and the interpreter is
    exited.
    
Compilation failed in require at /usr/share/YaST2/modules/Users.pm line 43 (#2)
BEGIN failed--compilation aborted at /usr/share/YaST2/modules/Users.pm line 43 (#3)
Compilation failed in require (#2)
BEGIN failed--compilation aborted (#3)
Uncaught exception from user code:
	Attempt to reload constant.pm aborted.
	Compilation failed in require at /usr/lib/perl5/5.38.2/x86_64-linux-thread-multi/Data/Dumper.pm line 20.
	BEGIN failed--compilation aborted at /usr/lib/perl5/5.38.2/x86_64-linux-thread-multi/Data/Dumper.pm line 20.
	Compilation failed in require at /usr/share/YaST2/modules/Users.pm line 43.
	BEGIN failed--compilation aborted at /usr/share/YaST2/modules/Users.pm line 43.
	Compilation failed in require.
	BEGIN failed--compilation aborted.
```
</Details>


## Likely Cause

Our workaround that set the global locale to the current one seems to have confused Perl; with the latest versions, it seems to rely on nobody from the outside changing the locale again.

This might be a reasonable assumption in the case of a standalone Perl interpreter, but we are using it as an embedded one.


## Fix

Revert the last change (PR #31).


## Affected Code Streams

Only Factory / Tumbleweed, not SLE-15-SPx or Leap 15.x or any older releases: We never submitted the workaround to anything other than Factory / Tumbleweed.


## Side Effects

https://bugzilla.suse.com/show_bug.cgi?id=1216689 (Japanese / German /Czech special characters broken in libstorage and Perl messages) will come back again; so we will still need a real fix for that one.

But a crash in all Perl-based YaST modules is much worse than some special characters in libstorage (and Perl modules) messages being replaced with a question mark `?` each.
