### PR TITLE
Use UTF-8 for translated texts coming from our Perl code (bsc#1216689)

### DIFF
--- a/package/yast2-perl-bindings.changes
+++ b/package/yast2-perl-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  3 09:46:46 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Use UTF-8 for translated texts coming from our Perl code (bsc#1216689),
+  fixing most '?' occurrences in yast2-users.
+- 5.0.3
+
+-------------------------------------------------------------------
 Wed Mar  6 14:03:01 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Revert the last locale fix to avoid Perl crashing (bsc#1220375)

--- a/package/yast2-perl-bindings.spec
+++ b/package/yast2-perl-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-perl-bindings
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YaPI.pm.in
+++ b/src/YaPI.pm.in
@@ -221,6 +221,7 @@ sub textdomain
     $textdomains{$package} = $domain;
     # substituted by configure
     Locale::gettext::bindtextdomain ($domain, "@yast2dir4perl@/locale");
+    Locale::gettext::bind_textdomain_locale ($domain, "UTF-8");
     return Locale::gettext::textdomain ($domain);
 }
 


### PR DESCRIPTION


## Problem

Without bind_textdomain_codeset, we get '?' for non-ASCII characters.

- https://bugzilla.suse.com/show_bug.cgi?id=1216689
- https://trello.com/c/RFe692G4


## Solution

Use `bind_locale_codeset`
We should really set our global locale codeset to UTF-8 instead of ASCII which Perl sets but how?

## Testing

- tested manually in a Tumbleweed inst-sys (by bind-mounting the read-only YaPI.pm to a writable copy /tmp/YaPI.pm, and patching that one)

## Screenshots

Before and after, the password problems popup during the installation.
Observe the **?** substitution characters.
Some of them are still left, coming from the `.crack` agent written in C++

![heslo-je-pxxlix-jednoduchx](https://github.com/yast/yast-perl-bindings/assets/102056/5447f0cb-1267-47d8-9ea0-ad69faca6457) 
![heslo-je-pxxlix-krxtkx](https://github.com/yast/yast-perl-bindings/assets/102056/d256d5bb-919c-42fc-814b-0cdee8177e42)

