### PR TITLE
Fix up PR 33

### DIFF
--- a/package/yast2-perl-bindings.changes
+++ b/package/yast2-perl-bindings.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Apr  5 11:18:46 UTC 2024 - Martin Vidner <mvidner@suse.com>
 
-- Fix an embarassing mistake in the previous change (bsc#1222375)
+- Fix downstream build failures caused by the previous change (bsc#1222375)
 - 5.0.4
 
 -------------------------------------------------------------------

--- a/package/yast2-perl-bindings.changes
+++ b/package/yast2-perl-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr  5 11:18:46 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Fix an embarassing mistake in the previous change (bsc#1222375)
+- 5.0.4
+
+-------------------------------------------------------------------
 Wed Apr  3 09:46:46 UTC 2024 - Martin Vidner <mvidner@suse.com>
 
 - Use UTF-8 for translated texts coming from our Perl code (bsc#1216689),

--- a/package/yast2-perl-bindings.spec
+++ b/package/yast2-perl-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-perl-bindings
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YaPI.pm.in
+++ b/src/YaPI.pm.in
@@ -221,7 +221,7 @@ sub textdomain
     $textdomains{$package} = $domain;
     # substituted by configure
     Locale::gettext::bindtextdomain ($domain, "@yast2dir4perl@/locale");
-    Locale::gettext::bind_textdomain_locale ($domain, "UTF-8");
+    Locale::gettext::bind_textdomain_codeset ($domain, "UTF-8");
     return Locale::gettext::textdomain ($domain);
 }
 


### PR DESCRIPTION
Fix an embarrassing mistake in the previous change, #33  ([bsc#1222375](https://bugzilla.suse.com/show_bug.cgi?id=1222375))


When you use the right library call in a VM and then copy it wrong in
your development repo. _and, **differently**, in the PR  description_

For example when building yast2-installation:
``` 
[   11s] Uncaught exception from user code:
[   11s] 	Missing constant bind_textdomain_locale at /usr/share/YaST2/modules/YaPI.pm line 224.
[   11s] 	Compilation failed in require.
[   11s] 	BEGIN failed--compilation aborted.
[   11s] rake aborted!
```

### Testing

This time red-green tested with `osc build` of yast2-installation both before and after this fix. Foolproof!!!